### PR TITLE
bolt logo clickable - redirect to bolt.new

### DIFF
--- a/components/common/LogoCircle.tsx
+++ b/components/common/LogoCircle.tsx
@@ -19,7 +19,11 @@ export default function LogoCircle() {
   const logoSrc = currentTheme === "dark" ? LOGO_DARK : LOGO_LIGHT;
 
   return (
-    <div className="w-24 h-24 rounded-full overflow-hidden border-2 border-slate-200 dark:border-slate-700 shadow-lg">
+    <div
+      className="w-24 h-24 rounded-full overflow-hidden border-2 border-slate-200 dark:border-slate-700 shadow-lg cursor-pointer"
+      onClick={() => window.open("https://bolt.new/", "_blank")}
+      title="Visit Bolt"
+    >
       <Image
         src={logoSrc}
         alt="Logo"


### PR DESCRIPTION
## Summary by Sourcery

Enable clicking on the Bolt logo to open bolt.new in a new browser tab

Enhancements:
- Make the LogoCircle component clickable by adding an onClick handler to open https://bolt.new
- Add a pointer cursor and title attribute to the logo container for better user affordance