### PR TITLE
removed growth score from productStats and GrowthStats

### DIFF
--- a/components/compare/GrowthStatsCard.tsx
+++ b/components/compare/GrowthStatsCard.tsx
@@ -35,10 +35,6 @@ export default function GrowthStatsCard({ growth }: { growth: any }) {
           <span>Stars Gained:</span>
           <b>{growth.stars_gained_last_month}</b>
         </div>
-        <div className="flex justify-between border-t pt-2 mt-2">
-          <span>Growth Score:</span>
-          <b className="text-green-700 dark:text-green-300">{growth.growth_score}</b>
-        </div>
       </CardContent>
     </Card>
   );

--- a/components/product/ProductStats.tsx
+++ b/components/product/ProductStats.tsx
@@ -17,10 +17,6 @@ export function ProductStats({ product }: { product: Product }) {
           ? `${product.contributors.toLocaleString()} contributors`
           : (product.forks ? `${product.forks.toLocaleString()} forks` : 'N/A')}
       </div>
-      <div className="flex items-center gap-1">
-        <Calendar className="h-3 w-3" />
-        {product.growth ? `Growth: ${product.growth.growth_score}/10` : '2024'}
-      </div>
       
     </div>
   );


### PR DESCRIPTION
## Summary by Sourcery

Remove the Growth Score metric display from product and growth statistics components.

Enhancements:
- Remove growth_score display from GrowthStatsCard
- Remove growth_score display from ProductStats